### PR TITLE
Laravel 13 support and Improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,57 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '8.0'
+            testbench: '^6.0'
+          - php: '8.1'
+            testbench: '^7.0'
+          - php: '8.1'
+            testbench: '^8.17'
+          - php: '8.2'
+            testbench: '^9.0'
+          - php: '8.2'
+            testbench: '^10.0'
+          - php: '8.3'
+            testbench: '^11.0'
+          - php: '8.4'
+            testbench: '^11.0'
+
+    name: PHP ${{ matrix.php }} / testbench ${{ matrix.testbench }}
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Cache Composer packages
+        uses: actions/cache@v5
+        with:
+          path: vendor
+          key: php-${{ matrix.php }}-testbench-${{ matrix.testbench }}-${{ hashFiles('composer.json') }}
+
+      - name: Configure Composer
+        run: composer config --global policy.advisories.block false
+
+      - name: Pin testbench version
+        run: composer require "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+
+      - name: Install dependencies
+        run: composer update --no-interaction --prefer-dist --no-progress
+
+      - name: Run tests
+        run: ./vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+.phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Değişiklik Geçmişi
+
+## [1.4.0] - 2026-06-22
+
+### Yeni Özellikler
+
+- **Laravel 13 desteği eklendi.**
+
+- **`GatewayRegistry` servisi ve `LaravelPos` facade'i eklendi.**
+  Gateway'lere artık container key'i yerine tip güvenli bir servis veya facade üzerinden erişilebilir:
+  ```php
+  // Servis injection
+  public function __construct(private \Mews\LaravelPos\GatewayRegistry $registry) {}
+  $pos = $this->registry->gateway('kuveytpos');
+
+  // Facade
+  $pos = \Mews\LaravelPos\Facades\LaravelPos::gateway('kuveytpos');
+
+  // Tüm gateway'ler
+  $all = $this->registry->all(); // PosInterface[]
+  ```
+
+- **`AccountFactoryInterface` ile özelleştirilebilir hesap fabrikası.**
+  `mews/pos`'ta yeni çıkan bir gateway için `laravel-pos` güncellemesini beklemeden kendi
+  implementasyonunuzu yazabilirsiniz. Bkz. [Özel AccountFactory Kullanımı](./docs/CUSTOM-ACCOUNT-FACTORY.md).
+
+
+### İyileştirmeler
+
+- **Gateway'ler artık ihtiyaç duyulduğunda oluşturuluyor (lazy loading).**
+  Daha önce tüm bankalar için gateway nesneleri uygulama başlangıcında oluşturuluyordu.
+  Artık her gateway yalnızca ilk erişimde oluşturulur ve sonraki çağrılarda önbellekten döner.
+
+- **KuveytPos ve PayFor endpoint URL'leri güncellendi.**
+
+---

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@
     # /config/laravel-pos.php
     return [
         'banks' => [
-            # array keyleri unique olmalıdır, bu keylerle Controller'larda su sekilde erisilebilir:
-            # $this->container->get('laravel-pos:gateway:kuveytpos');
+            # array keyleri unique olmalıdır
             'kuveytpos' => [ # ilk sıradaki banka injection için default olur.
                 'gateway_class'     => \Mews\Pos\Gateways\KuveytPos::class,
                 'lang'              => \Mews\Pos\PosInterface::LANG_TR,

--- a/README.md
+++ b/README.md
@@ -442,6 +442,16 @@ Route::match(['GET','POST'], '/payment/3d/response', [\App\Http\Controllers\Thre
 @endif
 ```
 
+### Tüm gateway'lere erişim
+
+Tüm yapılandırılmış gateway'lere `laravel-pos:gateway` etiketiyle erişebilirsiniz:
+
+```php
+$gateways = app()->tagged('laravel-pos:gateway'); // iterable, her eleman PosInterface
+```
+
+Birden fazla bankayı döngüyle kullanmak istediğinizde faydalıdır.
+
 ### Troubleshoots
 
 - Error: "_cURL error 60: SSL certificate problem: unable to get local issuer certificate (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for https://..._"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [Troubelshoots](#troubleshoots)
 - [Konfigurasyon Yapısı ve Örnekler](./docs/EXAMPLE_CONFIGURATIONS.md)
 - [API ve 3D Form verisini degiştirme](./docs/EXAMPLE-API-ISTEK-VE-3D-FORM-VERSINI-DEGISTIRME.md)
+- [Yeni Gateway için Özel AccountFactory Kullanımı](./docs/CUSTOM-ACCOUNT-FACTORY.md)
 
 ### Minimum Gereksinimler
 - PHP >= 7.4

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ### Minimum Gereksinimler
 - PHP >= 7.4
 - mews/pos ^1.7
-- laravel 8, 9, 10, 11, 12
+- laravel >= v8
 
 ### Kurulum
 1. 
@@ -74,7 +74,7 @@
 
 3. PHP Session kullanıyorsanız 3D ödemeler için session'i alttaki şekilde ayarlamanız gerekir.
     
-    **Laravel 11, 12** için environment değişkenleri şu şekilde olacak:
+    **Laravel 11 ve üzeri** için environment değişkenleri şu şekilde olacak:
     ```
     SESSION_SECURE_COOKIE=true
     SESSION_SAME_SITE=Lax # ya da SESSION_SAME_SITE=None deneyiniz.
@@ -93,7 +93,7 @@
 
 4. 3D ödemelerde bankadan websiteye geri redirect edilecek URL'larda (success/fail URL'lar) CSRF kapatılması gerekir.
 
-   **Laravel 11, 12** `withMiddleware()` method'la ayarı yapabilirsiniz.
+   **Laravel 11 ve üzeri** `withMiddleware()` method'la ayarı yapabilirsiniz.
 
     ```php
         <?php

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 - [Minimum Gereksinimler](#minimum-gereksinimler)
 - [Kurulum](#kurulum)
+- [Gateway'lere Erişim](#gatewaylere-erişim)
 - [Kullanım (3D Secure Ödeme)](#3d-secure-odeme-ornek-kullanim)
 - [Troubelshoots](#troubleshoots)
 - [Konfigurasyon Yapısı ve Örnekler](./docs/EXAMPLE_CONFIGURATIONS.md)
@@ -196,6 +197,27 @@
     }
     ```
 
+###  Gateway'lere Erişim
+
+Birden fazla banka yapılandırıldığında`GatewayRegistry` veya `LaravelPos`
+facade'i ile gateway'e erişebilirsiniz:
+
+```php
+use Mews\LaravelPos\GatewayRegistry;
+use Mews\LaravelPos\Facades\LaravelPos;
+
+// Constructor injection
+public function __construct(private GatewayRegistry $gatewayRegistry) {}
+$pos = $this->gatewayRegistry->gateway('kuveytpos'); // PosInterface
+
+// Facade
+$pos = LaravelPos::gateway('kuveytpos');
+
+// Tüm gateway'ler
+$all = $this->gatewayRegistry->all(); // PosInterface[]
+```
+
+Bilinmeyen bir `$bankKey` verilirse `\InvalidArgumentException` fırlatılır.
 
 
 ### 3D Secure Odeme Ornek Kullanim
@@ -225,17 +247,6 @@ class ThreeDSecurePaymentController extends Controller
         private PosInterface $pos,
     ) {
     }
-    
-    // START: birden fazla banka ile örnek:
-//    public function __construct(
-//        private Container $container,
-//    ) {}
-//    
-//    private function getPosService(string $bank): PosInterface
-//    {
-//        return $this->container->get('laravel-pos:gateway:'.$bank);
-//    }
-    // END: birden fazla banka ile örnek
 
     /**
      * route: /payment/3d/form
@@ -441,16 +452,6 @@ Route::match(['GET','POST'], '/payment/3d/response', [\App\Http\Controllers\Thre
    </script>
 @endif
 ```
-
-### Tüm gateway'lere erişim
-
-Tüm yapılandırılmış gateway'lere `laravel-pos:gateway` etiketiyle erişebilirsiniz:
-
-```php
-$gateways = app()->tagged('laravel-pos:gateway'); // iterable, her eleman PosInterface
-```
-
-Birden fazla bankayı döngüyle kullanmak istediğinizde faydalıdır.
 
 ### Troubleshoots
 

--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,16 @@
 		"mews/pos": "^1.7"
 	},
 	"require-dev": {
-		"orchestra/testbench": "^8.17|^9.0|^10.0|^11.0"
+		"orchestra/testbench": "^6.0|^7.0|^8.17|^9.0|^10.0|^11.0"
 	},
 	"autoload": {
 		"psr-4": {
 			"Mews\\LaravelPos\\": "src/"
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"Mews\\LaravelPos\\Tests\\": "tests/"
 		}
 	},
 	"extra": {

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,10 @@
 		"laravel": {
 			"providers": [
 				"Mews\\LaravelPos\\LaravelPosServiceProvider"
-			]
+			],
+			"aliases": {
+				"LaravelPos": "Mews\\LaravelPos\\Facades\\LaravelPos"
+			}
 		}
 	},
 	"config": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "mews/laravel-pos",
-	"description": "Laravel 11 Pos Package",
-	"keywords": ["laravel11 pos", "laravel11 sanal pos"],
+	"description": "Laravel Pos Package",
+	"keywords": ["laravel pos", "laravel sanal pos"],
 	"homepage": "https://github.com/mewebstudio/laravel-pos",
 	"minimum-stability": "stable",
 	"license": "MIT",
@@ -21,8 +21,8 @@
 	],
 	"require": {
 		"php": ">=7.4",
-		"illuminate/config": "^8.0|^9.0|^10.0|^11.0|^12.0",
-		"illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
+		"illuminate/config": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+		"illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
 		"mews/pos": "^1.7"
 	},
 	"require-dev": {

--- a/config/laravel-pos.php
+++ b/config/laravel-pos.php
@@ -51,7 +51,7 @@ return [
             ],
             'gateway_endpoints' => [ // Required
                 'payment_api'     => null, // Required
-                'gateway_3d'      => null, // Required
+                'gateway_3d'      => null, // Required for 3D payment models
                 'gateway_3d_host' => null,
                 'query_api'       => null,
             ],

--- a/docs/CUSTOM-ACCOUNT-FACTORY.md
+++ b/docs/CUSTOM-ACCOUNT-FACTORY.md
@@ -1,0 +1,115 @@
+# Özel AccountFactory Kullanımı
+
+`mews/pos` kütüphanesi yeni bir gateway yayımladığında, bu gateway için `AccountFactory`'ye destek
+eklenmeden önce kısa bir süre beklemek gerekebilir. Bu süreçte kendi `AccountFactoryInterface`
+implementasyonunuzu yazarak yeni gateway'i hemen kullanabilirsiniz.
+
+## Ne Zaman Gerekir?
+
+`AccountFactory`, `mews/pos`'un desteklediği her gateway için hesap nesnesi (`AbstractPosAccount`)
+oluşturmayı bilir. Ancak `mews/pos` yeni bir gateway çıkardığında ve `laravel-pos` henüz
+güncellenmemişse, o gateway için hesap oluşturma adımı başarısız olur ve `DomainException` fırlatılır.
+
+## Nasıl Yapılır?
+
+### 1. Özel Factory Sınıfı Oluşturun
+
+Bilinmeyen gateway için hesap oluşturma mantığını kendiniz yazın, geri kalan her şeyi varsayılan
+`AccountFactory`'ye delege edin.
+
+```php
+<?php
+# app/Factory/CustomAccountFactory.php
+
+namespace App\Factory;
+
+use Mews\LaravelPos\Factory\AccountFactoryInterface;
+use Mews\Pos\Entity\Account\AbstractPosAccount;
+use Mews\Pos\Factory\AccountFactory as MewsPosAccountFactory;
+use Mews\Pos\Gateways\NewBankPos; // mews/pos'un yeni eklediği gateway
+use Mews\Pos\PosInterface;
+
+class CustomAccountFactory implements AccountFactoryInterface
+{
+    public function __construct(private AccountFactoryInterface $default) {}
+
+    public function create(
+        string $gatewayClass,
+        string $name,
+        array  $credentials,
+        string $lang = PosInterface::LANG_TR
+    ): AbstractPosAccount {
+        if ($gatewayClass === NewBankPos::class) {
+            // mews/pos'un yeni gateway'i için uygun AccountFactory metodunu çağırın.
+            // Hangi metodu kullanacağınızı mews/pos kaynak kodundan öğrenebilirsiniz.
+            return MewsPosAccountFactory::createNewBankPosAccount(
+                $name,
+                $credentials['merchant_id'],
+                $credentials['enc_key'],
+                $credentials['payment_model'],
+                $lang,
+            );
+        }
+
+        // Desteklenen tüm diğer gateway'ler için varsayılan factory'e delege et.
+        return $this->default->create($gatewayClass, $name, $credentials, $lang);
+    }
+}
+```
+
+### 2. AppServiceProvider'a Kayıt Edin
+
+`CustomAccountFactory`, constructor'ında varsayılan `AccountFactoryInterface` implementasyonunu
+bekler. Bunu sağlamak için binding'i closure ile tanımlayın:
+
+```php
+<?php
+# app/Providers/AppServiceProvider.php
+
+namespace App\Providers;
+
+use App\Factory\CustomAccountFactory;
+use Illuminate\Support\ServiceProvider;
+use Mews\LaravelPos\Factory\AccountFactory;
+use Mews\LaravelPos\Factory\AccountFactoryInterface;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->singleton(AccountFactoryInterface::class, function () {
+            return new CustomAccountFactory(new AccountFactory());
+        });
+    }
+}
+```
+
+### 3. Konfigürasyona Yeni Gateway'i Ekleyin
+
+```php
+# config/laravel-pos.php
+
+return [
+    'banks' => [
+        'new_bank' => [
+            'gateway_class'     => \Mews\Pos\Gateways\NewBankPos::class,
+            'lang'              => \Mews\Pos\PosInterface::LANG_TR,
+            'credentials'       => [
+                'payment_model' => \Mews\Pos\PosInterface::MODEL_3D_SECURE,
+                'merchant_id'   => 'XXXXXXXX',
+                'enc_key'       => 'XXXXXXXX',
+            ],
+            'gateway_endpoints' => [
+                'payment_api' => 'https://...',
+                'gateway_3d'  => 'https://...',
+            ],
+        ],
+    ],
+];
+```
+
+## `laravel-pos` Güncellendiğinde
+
+`laravel-pos` yeni gateway için resmi destek eklediğinde `CustomAccountFactory`'yi kaldırabilir,
+`AppServiceProvider`'daki binding'i silebilirsiniz. Konfigürasyon dosyasında herhangi bir değişiklik
+gerekmez.

--- a/docs/EXAMPLE_CONFIGURATIONS.md
+++ b/docs/EXAMPLE_CONFIGURATIONS.md
@@ -144,9 +144,9 @@ return [
                 'mbr_id'        => \Mews\Pos\Entity\Account\PayForAccount::MBR_ID_FINANSBANK, // veya MBR_ID_ZIRAAT_KATILIM (Kurum Kodu)
             ],
             'gateway_endpoints' => [
-                'payment_api'     => 'https://vpostest.qnbfinansbank.com/Gateway/XMLGate.aspx',
-                'gateway_3d'      => 'https://vpostest.qnbfinansbank.com/Gateway/Default.aspx',
-                'gateway_3d_host' => 'https://vpostest.qnbfinansbank.com/Gateway/3DHost.aspx',
+                'payment_api'     => 'https://vpostest.qnb.com.tr/Gateway/XMLGate.aspx',
+                'gateway_3d'      => 'https://vpostest.qnb.com.tr/Gateway/Default.aspx',
+                'gateway_3d_host' => 'https://vpostest.qnb.com.tr/Gateway/3DHost.aspx',
             ],
         ],
         'payfor_ziraat_katilim'     => [

--- a/docs/EXAMPLE_CONFIGURATIONS.md
+++ b/docs/EXAMPLE_CONFIGURATIONS.md
@@ -57,7 +57,7 @@ return [
             ],
             'gateway_endpoints' => [ // Required
                  'payment_api'     => null, // Required
-                 'gateway_3d'      => null, // Required
+                 'gateway_3d'      => null, // Required for 3D payment models
                  'gateway_3d_host' => null,
                  'query_api'       => null,
             ],

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/Facades/LaravelPos.php
+++ b/src/Facades/LaravelPos.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Mews\LaravelPos\Facades;
+
+use Illuminate\Support\Facades\Facade;
+use Mews\LaravelPos\GatewayRegistry;
+use Mews\Pos\PosInterface;
+
+/**
+ * @method static PosInterface gateway(string $bankKey)
+ * @method static PosInterface[] all()
+ *
+ * @see GatewayRegistry
+ */
+class LaravelPos extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return GatewayRegistry::class;
+    }
+}

--- a/src/Factory/AccountFactory.php
+++ b/src/Factory/AccountFactory.php
@@ -2,6 +2,7 @@
 
 namespace Mews\LaravelPos\Factory;
 
+use Mews\LaravelPos\Factory\AccountFactoryInterface;
 use Mews\Pos\Entity\Account\AbstractPosAccount;
 use Mews\Pos\Entity\Account\PayFlexAccount;
 use Mews\Pos\Entity\Account\PayForAccount;
@@ -23,7 +24,7 @@ use Mews\Pos\Gateways\ToslaPos;
 use Mews\Pos\Gateways\VakifKatilimPos;
 use Mews\Pos\PosInterface;
 
-class AccountFactory
+class AccountFactory implements AccountFactoryInterface
 {
     /**
      * @param string $gatewayClass
@@ -36,7 +37,7 @@ class AccountFactory
      * @throws MissingAccountInfoException
      * @throws \DomainException
      */
-    public static function create(string $gatewayClass, string $name, array $credentials, string $lang = PosInterface::LANG_TR): AbstractPosAccount
+    public function create(string $gatewayClass, string $name, array $credentials, string $lang = PosInterface::LANG_TR): AbstractPosAccount
     {
         switch ($gatewayClass) {
             case EstPos::class:

--- a/src/Factory/AccountFactory.php
+++ b/src/Factory/AccountFactory.php
@@ -145,7 +145,7 @@ class AccountFactory
         }
 
         throw new \DomainException(
-            \sprintf('Can not create matching Account object for % gateway', $gatewayClass)
+            \sprintf('Can not create matching Account object for %s gateway', $gatewayClass)
         );
     }
 }

--- a/src/Factory/AccountFactory.php
+++ b/src/Factory/AccountFactory.php
@@ -24,6 +24,7 @@ use Mews\Pos\Gateways\ToslaPos;
 use Mews\Pos\Gateways\VakifKatilimPos;
 use Mews\Pos\PosInterface;
 
+/** @internal */
 class AccountFactory implements AccountFactoryInterface
 {
     /**

--- a/src/Factory/AccountFactoryInterface.php
+++ b/src/Factory/AccountFactoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Mews\LaravelPos\Factory;
+
+use Mews\Pos\Entity\Account\AbstractPosAccount;
+use Mews\Pos\Exceptions\MissingAccountInfoException;
+use Mews\Pos\PosInterface;
+
+interface AccountFactoryInterface
+{
+    /**
+     * @throws MissingAccountInfoException
+     * @throws \DomainException
+     */
+    public function create(
+        string $gatewayClass,
+        string $name,
+        array  $credentials,
+        string $lang = PosInterface::LANG_TR
+    ): AbstractPosAccount;
+}

--- a/src/Factory/GatewayFactory.php
+++ b/src/Factory/GatewayFactory.php
@@ -2,7 +2,6 @@
 
 namespace Mews\LaravelPos\Factory;
 
-use Mews\LaravelPos\Factory\AccountFactoryInterface;
 use Mews\Pos\Factory\CryptFactory;
 use Mews\Pos\Factory\HttpClientFactory;
 use Mews\Pos\Factory\RequestDataMapperFactory;
@@ -15,14 +14,24 @@ use Psr\Log\LoggerInterface;
 
 class GatewayFactory
 {
-    public static function create(
-        string                   $name,
-        array                    $options,
+    private AccountFactoryInterface $accountFactory;
+    private EventDispatcherInterface $eventDispatcher;
+    private LoggerInterface $logger;
+    private ClientInterface $client;
+
+    public function __construct(
         AccountFactoryInterface  $accountFactory,
         EventDispatcherInterface $eventDispatcher,
         LoggerInterface          $logger,
         ClientInterface          $client
-    ): PosInterface
+    ) {
+        $this->accountFactory  = $accountFactory;
+        $this->eventDispatcher = $eventDispatcher;
+        $this->logger          = $logger;
+        $this->client          = $client;
+    }
+
+    public function create(string $name, array $options): PosInterface
     {
         $credentials  = $options['credentials'];
         $gatewayClass = $options['gateway_class'];
@@ -32,22 +41,22 @@ class GatewayFactory
             );
         }
 
-        $account            = $accountFactory->create(
+        $account            = $this->accountFactory->create(
             $gatewayClass,
             $name,
             $credentials,
             $options['lang'] ?? PosInterface::LANG_TR
         );
-        $crypt              = CryptFactory::createGatewayCrypt($gatewayClass, $logger);
+        $crypt              = CryptFactory::createGatewayCrypt($gatewayClass, $this->logger);
         $requestDataMapper  = RequestDataMapperFactory::createGatewayRequestMapper(
             $gatewayClass,
-            $eventDispatcher,
+            $this->eventDispatcher,
             $crypt
         );
         $responseDataMapper = ResponseDataMapperFactory::createGatewayResponseMapper(
             $gatewayClass,
             $requestDataMapper,
-            $logger
+            $this->logger
         );
         $serializer         = SerializerFactory::createGatewaySerializer($gatewayClass);
 
@@ -55,15 +64,15 @@ class GatewayFactory
         $gateway = new $gatewayClass(
             [
                 'gateway_endpoints' => $options['gateway_endpoints'],
-                'gateway_configs' => $options['gateway_configs'] ?? [],
+                'gateway_configs'   => $options['gateway_configs'] ?? [],
             ],
             $account,
             $requestDataMapper,
             $responseDataMapper,
             $serializer,
-            $eventDispatcher,
-            HttpClientFactory::createHttpClient($client),
-            $logger,
+            $this->eventDispatcher,
+            HttpClientFactory::createHttpClient($this->client),
+            $this->logger,
         );
 
         if (!isset($options['gateway_configs']['test_mode']) && isset($options['test_mode'])) {

--- a/src/Factory/GatewayFactory.php
+++ b/src/Factory/GatewayFactory.php
@@ -2,6 +2,7 @@
 
 namespace Mews\LaravelPos\Factory;
 
+use Mews\LaravelPos\Factory\AccountFactoryInterface;
 use Mews\Pos\Factory\CryptFactory;
 use Mews\Pos\Factory\HttpClientFactory;
 use Mews\Pos\Factory\RequestDataMapperFactory;
@@ -17,6 +18,7 @@ class GatewayFactory
     public static function create(
         string                   $name,
         array                    $options,
+        AccountFactoryInterface  $accountFactory,
         EventDispatcherInterface $eventDispatcher,
         LoggerInterface          $logger,
         ClientInterface          $client
@@ -30,7 +32,7 @@ class GatewayFactory
             );
         }
 
-        $account            = AccountFactory::create(
+        $account            = $accountFactory->create(
             $gatewayClass,
             $name,
             $credentials,

--- a/src/Factory/GatewayFactory.php
+++ b/src/Factory/GatewayFactory.php
@@ -12,6 +12,7 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Log\LoggerInterface;
 
+/** @internal */
 class GatewayFactory
 {
     private AccountFactoryInterface $accountFactory;
@@ -75,6 +76,7 @@ class GatewayFactory
             $this->logger,
         );
 
+        // todo remove this in next major version
         if (!isset($options['gateway_configs']['test_mode']) && isset($options['test_mode'])) {
             $gateway->setTestMode($options['test_mode']);
         }

--- a/src/GatewayRegistry.php
+++ b/src/GatewayRegistry.php
@@ -2,6 +2,7 @@
 
 namespace Mews\LaravelPos;
 
+use Mews\LaravelPos\Factory\AccountFactoryInterface;
 use Mews\LaravelPos\Factory\GatewayFactory;
 use Mews\Pos\PosInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -17,14 +18,17 @@ class GatewayRegistry
     private EventDispatcherInterface $eventDispatcher;
     private LoggerInterface $logger;
     private ClientInterface $httpClient;
+    private AccountFactoryInterface $accountFactory;
 
     public function __construct(
         array $banks,
+        AccountFactoryInterface $accountFactory,
         EventDispatcherInterface $eventDispatcher,
         LoggerInterface $logger,
         ClientInterface $httpClient
     ) {
         $this->banks           = $banks;
+        $this->accountFactory  = $accountFactory;
         $this->eventDispatcher = $eventDispatcher;
         $this->logger          = $logger;
         $this->httpClient      = $httpClient;
@@ -42,6 +46,7 @@ class GatewayRegistry
             $this->resolved[$bankKey] = GatewayFactory::create(
                 $bankKey,
                 $this->banks[$bankKey],
+                $this->accountFactory,
                 $this->eventDispatcher,
                 $this->logger,
                 $this->httpClient,

--- a/src/GatewayRegistry.php
+++ b/src/GatewayRegistry.php
@@ -2,12 +2,8 @@
 
 namespace Mews\LaravelPos;
 
-use Mews\LaravelPos\Factory\AccountFactoryInterface;
 use Mews\LaravelPos\Factory\GatewayFactory;
 use Mews\Pos\PosInterface;
-use Psr\EventDispatcher\EventDispatcherInterface;
-use Psr\Http\Client\ClientInterface;
-use Psr\Log\LoggerInterface;
 
 class GatewayRegistry
 {
@@ -15,23 +11,12 @@ class GatewayRegistry
     private array $resolved = [];
 
     private array $banks;
-    private EventDispatcherInterface $eventDispatcher;
-    private LoggerInterface $logger;
-    private ClientInterface $httpClient;
-    private AccountFactoryInterface $accountFactory;
+    private GatewayFactory $gatewayFactory;
 
-    public function __construct(
-        array $banks,
-        AccountFactoryInterface $accountFactory,
-        EventDispatcherInterface $eventDispatcher,
-        LoggerInterface $logger,
-        ClientInterface $httpClient
-    ) {
-        $this->banks           = $banks;
-        $this->accountFactory  = $accountFactory;
-        $this->eventDispatcher = $eventDispatcher;
-        $this->logger          = $logger;
-        $this->httpClient      = $httpClient;
+    public function __construct(array $banks, GatewayFactory $gatewayFactory)
+    {
+        $this->banks          = $banks;
+        $this->gatewayFactory = $gatewayFactory;
     }
 
     public function gateway(string $bankKey): PosInterface
@@ -43,14 +28,7 @@ class GatewayRegistry
         }
 
         if (!isset($this->resolved[$bankKey])) {
-            $this->resolved[$bankKey] = GatewayFactory::create(
-                $bankKey,
-                $this->banks[$bankKey],
-                $this->accountFactory,
-                $this->eventDispatcher,
-                $this->logger,
-                $this->httpClient,
-            );
+            $this->resolved[$bankKey] = $this->gatewayFactory->create($bankKey, $this->banks[$bankKey]);
         }
 
         return $this->resolved[$bankKey];

--- a/src/GatewayRegistry.php
+++ b/src/GatewayRegistry.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Mews\LaravelPos;
+
+use Illuminate\Contracts\Container\Container;
+use Mews\Pos\PosInterface;
+
+class GatewayRegistry
+{
+    private Container $container;
+
+    public function __construct(Container $container)
+    {
+        $this->container = $container;
+    }
+
+    public function gateway(string $bankKey): PosInterface
+    {
+        $id = "laravel-pos:gateway:$bankKey";
+        if (!$this->container->bound($id)) {
+            throw new \InvalidArgumentException(
+                sprintf('No gateway registered for bank key "%s".', $bankKey)
+            );
+        }
+
+        return $this->container->make($id);
+    }
+
+    /**
+     * @return PosInterface[]
+     */
+    public function all(): array
+    {
+        return iterator_to_array($this->container->tagged('laravel-pos:gateway'));
+    }
+}

--- a/src/GatewayRegistry.php
+++ b/src/GatewayRegistry.php
@@ -2,28 +2,53 @@
 
 namespace Mews\LaravelPos;
 
-use Illuminate\Contracts\Container\Container;
+use Mews\LaravelPos\Factory\GatewayFactory;
 use Mews\Pos\PosInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Log\LoggerInterface;
 
 class GatewayRegistry
 {
-    private Container $container;
+    /** @var PosInterface[] */
+    private array $resolved = [];
 
-    public function __construct(Container $container)
-    {
-        $this->container = $container;
+    private array $banks;
+    private EventDispatcherInterface $eventDispatcher;
+    private LoggerInterface $logger;
+    private ClientInterface $httpClient;
+
+    public function __construct(
+        array $banks,
+        EventDispatcherInterface $eventDispatcher,
+        LoggerInterface $logger,
+        ClientInterface $httpClient
+    ) {
+        $this->banks           = $banks;
+        $this->eventDispatcher = $eventDispatcher;
+        $this->logger          = $logger;
+        $this->httpClient      = $httpClient;
     }
 
     public function gateway(string $bankKey): PosInterface
     {
-        $id = "laravel-pos:gateway:$bankKey";
-        if (!$this->container->bound($id)) {
+        if (!isset($this->banks[$bankKey])) {
             throw new \InvalidArgumentException(
                 sprintf('No gateway registered for bank key "%s".', $bankKey)
             );
         }
 
-        return $this->container->make($id);
+        if (!isset($this->resolved[$bankKey])) {
+            $this->resolved[$bankKey] = GatewayFactory::create(
+                $bankKey,
+                $this->banks[$bankKey],
+                $this->eventDispatcher,
+                $this->logger,
+                $this->httpClient,
+            );
+        }
+
+        return $this->resolved[$bankKey];
     }
 
     /**
@@ -31,6 +56,9 @@ class GatewayRegistry
      */
     public function all(): array
     {
-        return iterator_to_array($this->container->tagged('laravel-pos:gateway'));
+        return array_map(
+            fn(string $key) => $this->gateway($key),
+            array_keys($this->banks)
+        );
     }
 }

--- a/src/LaravelPosServiceProvider.php
+++ b/src/LaravelPosServiceProvider.php
@@ -6,7 +6,7 @@ use Http\Discovery\Psr18ClientDiscovery;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use Mews\LaravelPos\EventDispatcher\EventDispatcher;
-use Mews\LaravelPos\Factory\GatewayFactory;
+use Mews\LaravelPos\GatewayRegistry;
 use Mews\Pos\PosInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Client\ClientInterface;
@@ -38,38 +38,33 @@ class LaravelPosServiceProvider extends ServiceProvider {
      */
     public function register()
     {
-        $this->app->singleton(GatewayRegistry::class);
+        $this->app->singletonIf(EventDispatcherInterface::class, fn () => new EventDispatcher());
+        $this->app->singletonIf(ClientInterface::class, fn () => Psr18ClientDiscovery::find());
+
+        $this->app->singleton(GatewayRegistry::class, function (Application $app) {
+            return new GatewayRegistry(
+                config('laravel-pos.banks') ?? [],
+                $app->make(EventDispatcherInterface::class),
+                $app->make(LoggerInterface::class),
+                $app->make(ClientInterface::class),
+            );
+        });
 
         $banks = config('laravel-pos.banks');
-        if (null === $banks) {
+        if (empty($banks)) {
             return;
         }
 
-        $this->app->singletonIf(EventDispatcherInterface::class, function (Application $app) {
-            return new EventDispatcher();
-        });
-        $this->app->singletonIf(ClientInterface::class, function (Application $app) {
-            return Psr18ClientDiscovery::find();
-            // return Http::buildClient(); // this one gives Undefined array key "laravel_data" error when we make HTTP request
+        $firstKey = array_key_first($banks);
+        $this->app->singleton(PosInterface::class, function (Application $app) use ($firstKey) {
+            return $app->make(GatewayRegistry::class)->gateway($firstKey);
         });
 
-        $i = 0;
-        foreach ($banks as $bankKey => $bankConfig) {
+        foreach (array_keys($banks) as $bankKey) {
             $id = "laravel-pos:gateway:$bankKey";
-            $this->app->singleton($id, function(Application $app) use ($bankKey, $bankConfig) {
-                return GatewayFactory::create(
-                    $bankKey,
-                    $bankConfig,
-                    $app->make(EventDispatcherInterface::class),
-                    $app->make(LoggerInterface::class),
-                    $app->make(ClientInterface::class),
-                );
+            $this->app->singleton($id, function (Application $app) use ($bankKey) {
+                return $app->make(GatewayRegistry::class)->gateway($bankKey);
             });
-            if ($i === 0) {
-                // set default to inject for PosInterface
-                $this->app->singleton(PosInterface::class, $id);
-                $i++;
-            }
             $this->app->tag($id, 'laravel-pos:gateway');
         }
     }

--- a/src/LaravelPosServiceProvider.php
+++ b/src/LaravelPosServiceProvider.php
@@ -38,6 +38,8 @@ class LaravelPosServiceProvider extends ServiceProvider {
      */
     public function register()
     {
+        $this->app->singleton(GatewayRegistry::class);
+
         $banks = config('laravel-pos.banks');
         if (null === $banks) {
             return;

--- a/src/LaravelPosServiceProvider.php
+++ b/src/LaravelPosServiceProvider.php
@@ -6,6 +6,8 @@ use Http\Discovery\Psr18ClientDiscovery;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use Mews\LaravelPos\EventDispatcher\EventDispatcher;
+use Mews\LaravelPos\Factory\AccountFactory;
+use Mews\LaravelPos\Factory\AccountFactoryInterface;
 use Mews\LaravelPos\GatewayRegistry;
 use Mews\Pos\PosInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -40,6 +42,7 @@ class LaravelPosServiceProvider extends ServiceProvider {
     {
         $this->app->singletonIf(EventDispatcherInterface::class, fn () => new EventDispatcher());
         $this->app->singletonIf(ClientInterface::class, fn () => Psr18ClientDiscovery::find());
+        $this->app->singletonIf(AccountFactoryInterface::class, AccountFactory::class);
 
         $this->app->singleton(GatewayRegistry::class, function (Application $app) {
             return new GatewayRegistry(
@@ -47,6 +50,7 @@ class LaravelPosServiceProvider extends ServiceProvider {
                 $app->make(EventDispatcherInterface::class),
                 $app->make(LoggerInterface::class),
                 $app->make(ClientInterface::class),
+                $app->make(AccountFactoryInterface::class),
             );
         });
 

--- a/src/LaravelPosServiceProvider.php
+++ b/src/LaravelPosServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Support\ServiceProvider;
 use Mews\LaravelPos\EventDispatcher\EventDispatcher;
 use Mews\LaravelPos\Factory\AccountFactory;
 use Mews\LaravelPos\Factory\AccountFactoryInterface;
+use Mews\LaravelPos\Factory\GatewayFactory;
 use Mews\LaravelPos\GatewayRegistry;
 use Mews\Pos\PosInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -47,15 +48,17 @@ class LaravelPosServiceProvider extends ServiceProvider {
         $this->app->singleton(GatewayRegistry::class, function (Application $app) {
             return new GatewayRegistry(
                 config('laravel-pos.banks') ?? [],
-                $app->make(EventDispatcherInterface::class),
-                $app->make(LoggerInterface::class),
-                $app->make(ClientInterface::class),
-                $app->make(AccountFactoryInterface::class),
+                new GatewayFactory(
+                    $app->make(AccountFactoryInterface::class),
+                    $app->make(EventDispatcherInterface::class),
+                    $app->make(LoggerInterface::class),
+                    $app->make(ClientInterface::class),
+                ),
             );
         });
 
         $banks = config('laravel-pos.banks');
-        if (empty($banks)) {
+        if (null === $banks || [] === $banks) {
             return;
         }
 

--- a/tests/AccountFactoryTest.php
+++ b/tests/AccountFactoryTest.php
@@ -1,0 +1,265 @@
+<?php
+
+namespace Mews\LaravelPos\Tests;
+
+use Mews\LaravelPos\Factory\AccountFactory;
+use Mews\Pos\Entity\Account\AkbankPosAccount;
+use Mews\Pos\Entity\Account\EstPosAccount;
+use Mews\Pos\Entity\Account\GarantiPosAccount;
+use Mews\Pos\Entity\Account\InterPosAccount;
+use Mews\Pos\Entity\Account\KuveytPosAccount;
+use Mews\Pos\Entity\Account\ParamPosAccount;
+use Mews\Pos\Entity\Account\PayFlexAccount;
+use Mews\Pos\Entity\Account\PayForAccount;
+use Mews\Pos\Entity\Account\PosNetAccount;
+use Mews\Pos\Entity\Account\ToslaPosAccount;
+use Mews\Pos\Gateways\AkbankPos;
+use Mews\Pos\Gateways\EstPos;
+use Mews\Pos\Gateways\EstV3Pos;
+use Mews\Pos\Gateways\GarantiPos;
+use Mews\Pos\Gateways\InterPos;
+use Mews\Pos\Gateways\KuveytPos;
+use Mews\Pos\Gateways\ParamPos;
+use Mews\Pos\Gateways\PayFlexCPV4Pos;
+use Mews\Pos\Gateways\PayFlexV4Pos;
+use Mews\Pos\Gateways\PayForPos;
+use Mews\Pos\Gateways\PosNet;
+use Mews\Pos\Gateways\PosNetV1Pos;
+use Mews\Pos\Gateways\ToslaPos;
+use Mews\Pos\Gateways\VakifKatilimPos;
+use Mews\Pos\PosInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class AccountFactoryTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, array<string, mixed>, class-string}>
+     */
+    public static function gatewayAccountProvider(): iterable
+    {
+        yield 'EstPos' => [
+            EstPos::class,
+            [
+                'payment_model' => PosInterface::MODEL_NON_SECURE,
+                'merchant_id'   => '700655000200',
+                'user_name'     => 'ISBANKAPI',
+                'user_password' => 'ISBANK07',
+                'enc_key'       => 'TRPS0200',
+            ],
+            EstPosAccount::class,
+        ];
+
+        yield 'EstV3Pos' => [
+            EstV3Pos::class,
+            [
+                'payment_model' => PosInterface::MODEL_NON_SECURE,
+                'merchant_id'   => '700655000200',
+                'user_name'     => 'ISBANKAPI',
+                'user_password' => 'ISBANK07',
+            ],
+            EstPosAccount::class,
+        ];
+
+        yield 'PosNet' => [
+            PosNet::class,
+            [
+                'payment_model' => PosInterface::MODEL_NON_SECURE,
+                'merchant_id'   => '6701950031',
+                'terminal_id'   => '67540050',
+                'user_name'     => '27426',
+                'enc_key'       => '10,10,10,10,10,10,10,10',
+            ],
+            PosNetAccount::class,
+        ];
+
+        yield 'PosNetV1Pos' => [
+            PosNetV1Pos::class,
+            [
+                'payment_model' => PosInterface::MODEL_NON_SECURE,
+                'merchant_id'   => '6701950031',
+                'terminal_id'   => '67540050',
+                'user_name'     => '27426',
+            ],
+            PosNetAccount::class,
+        ];
+
+        yield 'PayForPos' => [
+            PayForPos::class,
+            [
+                'payment_model' => PosInterface::MODEL_NON_SECURE,
+                'merchant_id'   => '085300000009704',
+                'user_name'     => 'QNB_API_KULLANICI_3DPAY',
+                'user_password' => 'UcBN0',
+                'enc_key'       => '12345678',
+            ],
+            PayForAccount::class,
+        ];
+
+        yield 'GarantiPos' => [
+            GarantiPos::class,
+            [
+                'payment_model'        => PosInterface::MODEL_NON_SECURE,
+                'merchant_id'          => '7000679',
+                'user_name'            => 'PROVAUT',
+                'user_password'        => '123qweASD',
+                'terminal_id'          => '30691298',
+                'enc_key'              => '12345678',
+                'refund_user_name'     => 'PROVRFN',
+                'refund_user_password' => '123qweASD',
+            ],
+            GarantiPosAccount::class,
+        ];
+
+        yield 'InterPos' => [
+            InterPos::class,
+            [
+                'payment_model' => PosInterface::MODEL_NON_SECURE,
+                'merchant_id'   => '3123',
+                'user_name'     => 'InterTestApi',
+                'user_password' => '3',
+                'enc_key'       => 'gDg1N',
+            ],
+            InterPosAccount::class,
+        ];
+
+        yield 'KuveytPos' => [
+            KuveytPos::class,
+            [
+                'payment_model' => PosInterface::MODEL_3D_SECURE,
+                'merchant_id'   => '496',
+                'user_name'     => 'apitest',
+                'terminal_id'   => '4961',
+                'enc_key'       => 'api123',
+            ],
+            KuveytPosAccount::class,
+        ];
+
+        yield 'VakifKatilimPos' => [
+            VakifKatilimPos::class,
+            [
+                'payment_model' => PosInterface::MODEL_3D_SECURE,
+                'merchant_id'   => '1',
+                'user_name'     => 'apitest',
+                'terminal_id'   => '1',
+                'enc_key'       => 'api123',
+            ],
+            KuveytPosAccount::class,
+        ];
+
+        yield 'PayFlexV4Pos' => [
+            PayFlexV4Pos::class,
+            [
+                'payment_model' => PosInterface::MODEL_NON_SECURE,
+                'merchant_id'   => 'M001',
+                'user_password' => 'P001',
+                'terminal_id'   => 'VP000579',
+            ],
+            PayFlexAccount::class,
+        ];
+
+        yield 'PayFlexCPV4Pos' => [
+            PayFlexCPV4Pos::class,
+            [
+                'payment_model' => PosInterface::MODEL_NON_SECURE,
+                'merchant_id'   => 'M001',
+                'user_password' => 'P001',
+                'terminal_id'   => 'VP000579',
+            ],
+            PayFlexAccount::class,
+        ];
+
+        yield 'AkbankPos' => [
+            AkbankPos::class,
+            [
+                'merchant_id' => '2023090417500272654BD9A49CF07574',
+                'terminal_id' => '2023090417500284633D137A249DBBEB',
+                'enc_key'     => 'c1PPl+2rNNBB2LwmQe9SrGHKa3XJYiCEFMBOd1l3244=',
+            ],
+            AkbankPosAccount::class,
+        ];
+
+        yield 'ToslaPos' => [
+            ToslaPos::class,
+            [
+                'merchant_id' => '1000000494',
+                'user_name'   => 'POS_ENT_APISI_KULLANICI',
+                'enc_key'     => '33333',
+            ],
+            ToslaPosAccount::class,
+        ];
+
+        yield 'ParamPos' => [
+            ParamPos::class,
+            [
+                'merchant_id'   => 10738,
+                'user_name'     => 'Test',
+                'user_password' => 'Test',
+                'enc_key'       => '0c13d406-873b-403b-9c09-a5766840d98c',
+            ],
+            ParamPosAccount::class,
+        ];
+    }
+
+    /**
+     * @dataProvider gatewayAccountProvider
+     * @param class-string $gatewayClass
+     * @param array<string, mixed> $credentials
+     * @param class-string $expectedAccountClass
+     */
+    #[DataProvider('gatewayAccountProvider')]
+    public function test_creates_correct_account_type(
+        string $gatewayClass,
+        array  $credentials,
+        string $expectedAccountClass
+    ): void {
+        $account = AccountFactory::create($gatewayClass, 'test_bank', $credentials);
+
+        $this->assertInstanceOf($expectedAccountClass, $account);
+    }
+
+    /** @dataProvider gatewayAccountProvider */
+    #[DataProvider('gatewayAccountProvider')]
+    public function test_account_bank_name_is_preserved(
+        string $gatewayClass,
+        array  $credentials,
+        string $_expectedAccountClass
+    ): void {
+        $account = AccountFactory::create($gatewayClass, 'my_bank', $credentials);
+
+        $this->assertSame('my_bank', $account->getBank());
+    }
+
+    public function test_throws_domain_exception_for_unknown_gateway(): void
+    {
+        $this->expectException(\DomainException::class);
+
+        AccountFactory::create(\stdClass::class, 'test_bank', [
+            'payment_model' => PosInterface::MODEL_NON_SECURE,
+        ]);
+    }
+
+    public function test_account_lang_is_passed_through(): void
+    {
+        $account = AccountFactory::create(EstPos::class, 'test_bank', [
+            'payment_model' => PosInterface::MODEL_NON_SECURE,
+            'merchant_id'   => '700655000200',
+            'user_name'     => 'ISBANKAPI',
+            'user_password' => 'ISBANK07',
+        ], PosInterface::LANG_EN);
+
+        $this->assertSame(PosInterface::LANG_EN, $account->getLang());
+    }
+
+    public function test_default_lang_is_turkish(): void
+    {
+        $account = AccountFactory::create(EstPos::class, 'test_bank', [
+            'payment_model' => PosInterface::MODEL_NON_SECURE,
+            'merchant_id'   => '700655000200',
+            'user_name'     => 'ISBANKAPI',
+            'user_password' => 'ISBANK07',
+        ]);
+
+        $this->assertSame(PosInterface::LANG_TR, $account->getLang());
+    }
+}

--- a/tests/AccountFactoryTest.php
+++ b/tests/AccountFactoryTest.php
@@ -213,7 +213,7 @@ class AccountFactoryTest extends TestCase
         array  $credentials,
         string $expectedAccountClass
     ): void {
-        $account = AccountFactory::create($gatewayClass, 'test_bank', $credentials);
+        $account = (new AccountFactory())->create($gatewayClass, 'test_bank', $credentials);
 
         $this->assertInstanceOf($expectedAccountClass, $account);
     }
@@ -225,7 +225,7 @@ class AccountFactoryTest extends TestCase
         array  $credentials,
         string $_expectedAccountClass
     ): void {
-        $account = AccountFactory::create($gatewayClass, 'my_bank', $credentials);
+        $account = (new AccountFactory())->create($gatewayClass, 'my_bank', $credentials);
 
         $this->assertSame('my_bank', $account->getBank());
     }
@@ -235,14 +235,14 @@ class AccountFactoryTest extends TestCase
         $this->expectException(\DomainException::class);
         $this->expectExceptionMessageMatches('/stdClass/');
 
-        AccountFactory::create(\stdClass::class, 'test_bank', [
+        (new AccountFactory())->create(\stdClass::class, 'test_bank', [
             'payment_model' => PosInterface::MODEL_NON_SECURE,
         ]);
     }
 
     public function test_account_lang_is_passed_through(): void
     {
-        $account = AccountFactory::create(EstPos::class, 'test_bank', [
+        $account = (new AccountFactory())->create(EstPos::class, 'test_bank', [
             'payment_model' => PosInterface::MODEL_NON_SECURE,
             'merchant_id'   => '700655000200',
             'user_name'     => 'ISBANKAPI',
@@ -254,7 +254,7 @@ class AccountFactoryTest extends TestCase
 
     public function test_default_lang_is_turkish(): void
     {
-        $account = AccountFactory::create(EstPos::class, 'test_bank', [
+        $account = (new AccountFactory())->create(EstPos::class, 'test_bank', [
             'payment_model' => PosInterface::MODEL_NON_SECURE,
             'merchant_id'   => '700655000200',
             'user_name'     => 'ISBANKAPI',

--- a/tests/AccountFactoryTest.php
+++ b/tests/AccountFactoryTest.php
@@ -233,6 +233,7 @@ class AccountFactoryTest extends TestCase
     public function test_throws_domain_exception_for_unknown_gateway(): void
     {
         $this->expectException(\DomainException::class);
+        $this->expectExceptionMessageMatches('/stdClass/');
 
         AccountFactory::create(\stdClass::class, 'test_bank', [
             'payment_model' => PosInterface::MODEL_NON_SECURE,

--- a/tests/EventDispatcherTest.php
+++ b/tests/EventDispatcherTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Mews\LaravelPos\Tests;
+
+use Illuminate\Support\Facades\Event;
+use Mews\LaravelPos\EventDispatcher\EventDispatcher;
+use Orchestra\Testbench\TestCase;
+
+class EventDispatcherTest extends TestCase
+{
+    public function test_dispatch_returns_the_event(): void
+    {
+        $dispatcher = new EventDispatcher();
+        $event = new \stdClass();
+
+        $result = $dispatcher->dispatch($event);
+
+        $this->assertSame($event, $result);
+    }
+
+    public function test_dispatch_fires_laravel_event(): void
+    {
+        Event::fake();
+
+        $dispatcher = new EventDispatcher();
+        $event = new \stdClass();
+        $dispatcher->dispatch($event);
+
+        Event::assertDispatched(\stdClass::class);
+    }
+}

--- a/tests/GatewayFactoryTest.php
+++ b/tests/GatewayFactoryTest.php
@@ -3,7 +3,10 @@
 namespace Mews\LaravelPos\Tests;
 
 use Mews\LaravelPos\EventDispatcher\EventDispatcher;
+use Mews\LaravelPos\Factory\AccountFactory;
+use Mews\LaravelPos\Factory\AccountFactoryInterface;
 use Mews\LaravelPos\Factory\GatewayFactory;
+use Mews\Pos\Entity\Account\AbstractPosAccount;
 use Mews\Pos\Gateways\EstPos;
 use Mews\Pos\PosInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -21,6 +24,7 @@ class GatewayFactoryTest extends TestCase
             new EventDispatcher(),
             $this->createStub(LoggerInterface::class),
             $this->createStub(ClientInterface::class),
+            new AccountFactory(),
         );
 
         $this->assertInstanceOf(PosInterface::class, $gateway);
@@ -37,6 +41,7 @@ class GatewayFactoryTest extends TestCase
             new EventDispatcher(),
             $this->createStub(LoggerInterface::class),
             $this->createStub(ClientInterface::class),
+            new AccountFactory(),
         );
     }
 
@@ -79,9 +84,31 @@ class GatewayFactoryTest extends TestCase
             new EventDispatcher(),
             $this->createStub(LoggerInterface::class),
             $this->createStub(ClientInterface::class),
+            new AccountFactory(),
         );
 
         $this->assertSame($expectedTestMode, $gateway->isTestMode());
+    }
+
+    public function test_delegates_account_creation_to_provided_factory(): void
+    {
+        $mockFactory = $this->createMock(AccountFactoryInterface::class);
+        $mockFactory->expects($this->once())
+            ->method('create')
+            ->willReturn((new AccountFactory())->create(
+                EstPos::class,
+                'test_bank',
+                self::baseConfig()['credentials'],
+            ));
+
+        GatewayFactory::create(
+            'test_bank',
+            self::baseConfig(),
+            new EventDispatcher(),
+            $this->createStub(LoggerInterface::class),
+            $this->createStub(ClientInterface::class),
+            $mockFactory,
+        );
     }
 
     /**

--- a/tests/GatewayFactoryTest.php
+++ b/tests/GatewayFactoryTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Mews\LaravelPos\Tests;
+
+use Mews\LaravelPos\EventDispatcher\EventDispatcher;
+use Mews\LaravelPos\Factory\GatewayFactory;
+use Mews\Pos\Gateways\EstPos;
+use Mews\Pos\PosInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Log\LoggerInterface;
+
+class GatewayFactoryTest extends TestCase
+{
+    public function test_creates_pos_interface_instance(): void
+    {
+        $gateway = GatewayFactory::create(
+            'test_bank',
+            self::baseConfig(),
+            new EventDispatcher(),
+            $this->createStub(LoggerInterface::class),
+            $this->createStub(ClientInterface::class),
+        );
+
+        $this->assertInstanceOf(PosInterface::class, $gateway);
+        $this->assertInstanceOf(EstPos::class, $gateway);
+    }
+
+    public function test_throws_for_non_pos_interface_gateway_class(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        GatewayFactory::create(
+            'test_bank',
+            array_merge(self::baseConfig(), ['gateway_class' => \stdClass::class]),
+            new EventDispatcher(),
+            $this->createStub(LoggerInterface::class),
+            $this->createStub(ClientInterface::class),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>, bool}>
+     */
+    public static function provide_test_mode_cases(): iterable
+    {
+        yield 'enabled via gateway_configs' => [
+            ['gateway_configs' => ['test_mode' => true]],
+            true,
+        ];
+
+        yield 'enabled via legacy option' => [
+            ['gateway_configs' => [], 'test_mode' => true],
+            true,
+        ];
+
+        yield 'gateway_configs takes precedence over legacy' => [
+            ['gateway_configs' => ['test_mode' => false], 'test_mode' => true],
+            false,
+        ];
+
+        yield 'disabled by default' => [
+            [],
+            false,
+        ];
+    }
+
+    /**
+     * @dataProvider provide_test_mode_cases
+     * @param array<string, mixed> $configOverrides
+     */
+    #[DataProvider('provide_test_mode_cases')]
+    public function test_test_mode(array $configOverrides, bool $expectedTestMode): void
+    {
+        $gateway = GatewayFactory::create(
+            'test_bank',
+            array_merge(self::baseConfig(), $configOverrides),
+            new EventDispatcher(),
+            $this->createStub(LoggerInterface::class),
+            $this->createStub(ClientInterface::class),
+        );
+
+        $this->assertSame($expectedTestMode, $gateway->isTestMode());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function baseConfig(): array
+    {
+        return [
+            'gateway_class'     => EstPos::class,
+            'lang'              => PosInterface::LANG_TR,
+            'credentials'       => [
+                'payment_model' => PosInterface::MODEL_NON_SECURE,
+                'merchant_id'   => '700655000200',
+                'user_name'     => 'ISBANKAPI',
+                'user_password' => 'ISBANK07',
+                'enc_key'       => 'TRPS0200',
+            ],
+            'gateway_endpoints' => [
+                'payment_api'     => 'https://entegrasyon.asseco-see.com.tr/fim/api',
+                'gateway_3d'      => 'https://entegrasyon.asseco-see.com.tr/fim/est3Dgate',
+                'gateway_3d_host' => null,
+                'query_api'       => null,
+            ],
+            'gateway_configs'   => [],
+        ];
+    }
+}

--- a/tests/GatewayFactoryTest.php
+++ b/tests/GatewayFactoryTest.php
@@ -6,7 +6,6 @@ use Mews\LaravelPos\EventDispatcher\EventDispatcher;
 use Mews\LaravelPos\Factory\AccountFactory;
 use Mews\LaravelPos\Factory\AccountFactoryInterface;
 use Mews\LaravelPos\Factory\GatewayFactory;
-use Mews\Pos\Entity\Account\AbstractPosAccount;
 use Mews\Pos\Gateways\EstPos;
 use Mews\Pos\PosInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -18,14 +17,7 @@ class GatewayFactoryTest extends TestCase
 {
     public function test_creates_pos_interface_instance(): void
     {
-        $gateway = GatewayFactory::create(
-            'test_bank',
-            self::baseConfig(),
-            new EventDispatcher(),
-            $this->createStub(LoggerInterface::class),
-            $this->createStub(ClientInterface::class),
-            new AccountFactory(),
-        );
+        $gateway = $this->makeFactory()->create('test_bank', self::baseConfig());
 
         $this->assertInstanceOf(PosInterface::class, $gateway);
         $this->assertInstanceOf(EstPos::class, $gateway);
@@ -35,13 +27,9 @@ class GatewayFactoryTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        GatewayFactory::create(
+        $this->makeFactory()->create(
             'test_bank',
-            array_merge(self::baseConfig(), ['gateway_class' => \stdClass::class]),
-            new EventDispatcher(),
-            $this->createStub(LoggerInterface::class),
-            $this->createStub(ClientInterface::class),
-            new AccountFactory(),
+            array_merge(self::baseConfig(), ['gateway_class' => \stdClass::class])
         );
     }
 
@@ -78,22 +66,15 @@ class GatewayFactoryTest extends TestCase
     #[DataProvider('provide_test_mode_cases')]
     public function test_test_mode(array $configOverrides, bool $expectedTestMode): void
     {
-        $gateway = GatewayFactory::create(
-            'test_bank',
-            array_merge(self::baseConfig(), $configOverrides),
-            new EventDispatcher(),
-            $this->createStub(LoggerInterface::class),
-            $this->createStub(ClientInterface::class),
-            new AccountFactory(),
-        );
+        $gateway = $this->makeFactory()->create('test_bank', array_merge(self::baseConfig(), $configOverrides));
 
         $this->assertSame($expectedTestMode, $gateway->isTestMode());
     }
 
     public function test_delegates_account_creation_to_provided_factory(): void
     {
-        $mockFactory = $this->createMock(AccountFactoryInterface::class);
-        $mockFactory->expects($this->once())
+        $mockAccountFactory = $this->createMock(AccountFactoryInterface::class);
+        $mockAccountFactory->expects($this->once())
             ->method('create')
             ->willReturn((new AccountFactory())->create(
                 EstPos::class,
@@ -101,13 +82,16 @@ class GatewayFactoryTest extends TestCase
                 self::baseConfig()['credentials'],
             ));
 
-        GatewayFactory::create(
-            'test_bank',
-            self::baseConfig(),
+        $this->makeFactory($mockAccountFactory)->create('test_bank', self::baseConfig());
+    }
+
+    private function makeFactory(?AccountFactoryInterface $accountFactory = null): GatewayFactory
+    {
+        return new GatewayFactory(
+            $accountFactory ?? new AccountFactory(),
             new EventDispatcher(),
             $this->createStub(LoggerInterface::class),
             $this->createStub(ClientInterface::class),
-            $mockFactory,
         );
     }
 

--- a/tests/GatewayRegistryTest.php
+++ b/tests/GatewayRegistryTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Mews\LaravelPos\Tests;
+
+use Mews\LaravelPos\GatewayRegistry;
+use Mews\LaravelPos\LaravelPosServiceProvider;
+use Mews\Pos\Gateways\EstPos;
+use Mews\Pos\Gateways\GarantiPos;
+use Mews\Pos\PosInterface;
+use Orchestra\Testbench\TestCase;
+
+class GatewayRegistryTest extends TestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return [];
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('laravel-pos.banks', [
+            'est_bank'     => $this->makeEstPosConfig(),
+            'garanti_bank' => $this->makeGarantiPosConfig(),
+        ]);
+
+        $app->register(LaravelPosServiceProvider::class);
+    }
+
+    public function test_registry_is_bound(): void
+    {
+        $this->assertInstanceOf(GatewayRegistry::class, $this->app->make(GatewayRegistry::class));
+    }
+
+    public function test_gateway_returns_pos_interface(): void
+    {
+        $registry = $this->app->make(GatewayRegistry::class);
+
+        $this->assertInstanceOf(PosInterface::class, $registry->gateway('est_bank'));
+    }
+
+    public function test_gateway_returns_correct_class_per_bank_key(): void
+    {
+        $registry = $this->app->make(GatewayRegistry::class);
+
+        $this->assertInstanceOf(EstPos::class, $registry->gateway('est_bank'));
+        $this->assertInstanceOf(GarantiPos::class, $registry->gateway('garanti_bank'));
+    }
+
+    public function test_gateway_returns_same_singleton_instance(): void
+    {
+        $registry = $this->app->make(GatewayRegistry::class);
+
+        $this->assertSame($registry->gateway('est_bank'), $registry->gateway('est_bank'));
+    }
+
+    public function test_all_returns_all_configured_gateways(): void
+    {
+        $registry = $this->app->make(GatewayRegistry::class);
+
+        $this->assertCount(2, $registry->all());
+    }
+
+    public function test_all_returns_pos_interface_instances(): void
+    {
+        $registry = $this->app->make(GatewayRegistry::class);
+
+        foreach ($registry->all() as $gateway) {
+            $this->assertInstanceOf(PosInterface::class, $gateway);
+        }
+    }
+
+    public function test_gateway_throws_for_unknown_bank_key(): void
+    {
+        $registry = $this->app->make(GatewayRegistry::class);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/unknown_bank/');
+
+        $registry->gateway('unknown_bank');
+    }
+
+    public function test_registry_is_bound_even_when_no_banks_configured(): void
+    {
+        $app = $this->createApplication();
+        $app['config']->set('laravel-pos.banks', null);
+        $app->register(LaravelPosServiceProvider::class);
+
+        $this->assertInstanceOf(GatewayRegistry::class, $app->make(GatewayRegistry::class));
+    }
+
+    private function makeEstPosConfig(): array
+    {
+        return [
+            'gateway_class'     => EstPos::class,
+            'lang'              => PosInterface::LANG_TR,
+            'credentials'       => [
+                'payment_model' => PosInterface::MODEL_NON_SECURE,
+                'merchant_id'   => '700655000200',
+                'user_name'     => 'ISBANKAPI',
+                'user_password' => 'ISBANK07',
+                'enc_key'       => 'TRPS0200',
+            ],
+            'gateway_endpoints' => [
+                'payment_api'     => 'https://entegrasyon.asseco-see.com.tr/fim/api',
+                'gateway_3d'      => 'https://entegrasyon.asseco-see.com.tr/fim/est3Dgate',
+                'gateway_3d_host' => null,
+                'query_api'       => null,
+            ],
+            'gateway_configs'   => [],
+        ];
+    }
+
+    private function makeGarantiPosConfig(): array
+    {
+        return [
+            'gateway_class'     => GarantiPos::class,
+            'lang'              => PosInterface::LANG_TR,
+            'credentials'       => [
+                'payment_model'        => PosInterface::MODEL_NON_SECURE,
+                'merchant_id'          => '7000679',
+                'user_name'            => 'PROVAUT',
+                'user_password'        => '123qweASD',
+                'terminal_id'          => '30691298',
+                'enc_key'              => '12345678',
+                'refund_user_name'     => 'PROVRFN',
+                'refund_user_password' => '123qweASD',
+            ],
+            'gateway_endpoints' => [
+                'payment_api'     => 'https://sanalposprovtest.garanti.com.tr/VPServlet',
+                'gateway_3d'      => 'https://sanalposprovtest.garanti.com.tr/servlet/gt3dengine',
+                'gateway_3d_host' => null,
+                'query_api'       => null,
+            ],
+            'gateway_configs'   => [],
+        ];
+    }
+}

--- a/tests/LaravelPosServiceProviderNoBanksTest.php
+++ b/tests/LaravelPosServiceProviderNoBanksTest.php
@@ -26,7 +26,7 @@ class LaravelPosServiceProviderNoBanksTest extends TestCase
 
     public function test_no_gateways_tagged_when_banks_is_null(): void
     {
-        $gateways = iterator_to_array($this->app->tagged('laravel-pos:gateway'));
+        $gateways = [...$this->app->tagged('laravel-pos:gateway')];
 
         $this->assertEmpty($gateways);
     }

--- a/tests/LaravelPosServiceProviderNoBanksTest.php
+++ b/tests/LaravelPosServiceProviderNoBanksTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Mews\LaravelPos\Tests;
+
+use Mews\LaravelPos\LaravelPosServiceProvider;
+use Mews\Pos\PosInterface;
+use Orchestra\Testbench\TestCase;
+
+class LaravelPosServiceProviderNoBanksTest extends TestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return [];
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('laravel-pos.banks', null);
+        $app->register(LaravelPosServiceProvider::class);
+    }
+
+    public function test_pos_interface_is_not_bound_when_banks_is_null(): void
+    {
+        $this->assertFalse($this->app->bound(PosInterface::class));
+    }
+
+    public function test_no_gateways_tagged_when_banks_is_null(): void
+    {
+        $gateways = iterator_to_array($this->app->tagged('laravel-pos:gateway'));
+
+        $this->assertEmpty($gateways);
+    }
+}

--- a/tests/LaravelPosServiceProviderTest.php
+++ b/tests/LaravelPosServiceProviderTest.php
@@ -6,6 +6,7 @@ use Mews\LaravelPos\LaravelPosServiceProvider;
 use Mews\Pos\Gateways\EstPos;
 use Mews\Pos\Gateways\GarantiPos;
 use Mews\Pos\PosInterface;
+
 use Orchestra\Testbench\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Client\ClientInterface;
@@ -77,6 +78,16 @@ class LaravelPosServiceProviderTest extends TestCase
         $gateways = iterator_to_array($this->app->tagged('laravel-pos:gateway'));
 
         $this->assertCount(2, $gateways);
+    }
+
+    public function test_all_access_paths_return_the_same_instance(): void
+    {
+        $registry = $this->app->make(\Mews\LaravelPos\GatewayRegistry::class);
+        $viaKey   = $this->app->make('laravel-pos:gateway:est_bank');
+        $tagged   = iterator_to_array($this->app->tagged('laravel-pos:gateway'));
+
+        $this->assertSame($viaKey, $registry->gateway('est_bank'));
+        $this->assertSame($viaKey, $tagged[0]);
     }
 
     public function test_config_is_publishable(): void

--- a/tests/LaravelPosServiceProviderTest.php
+++ b/tests/LaravelPosServiceProviderTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Mews\LaravelPos\Tests;
+
+use Mews\LaravelPos\LaravelPosServiceProvider;
+use Mews\Pos\Gateways\EstPos;
+use Mews\Pos\Gateways\GarantiPos;
+use Mews\Pos\PosInterface;
+use Orchestra\Testbench\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Http\Client\ClientInterface;
+
+/**
+ * Tests register() with two banks configured.
+ *
+ * The provider is registered manually in defineEnvironment (after config is set)
+ * because register() reads config eagerly — before testbench's normal provider
+ * boot phase would have set it.
+ */
+class LaravelPosServiceProviderTest extends TestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return [];
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('laravel-pos.banks', [
+            'est_bank'     => $this->makeEstPosConfig(),
+            'garanti_bank' => $this->makeGarantiPosConfig(),
+        ]);
+
+        $app->register(LaravelPosServiceProvider::class);
+    }
+
+    public function test_pos_interface_is_bound(): void
+    {
+        $this->assertInstanceOf(PosInterface::class, $this->app->make(PosInterface::class));
+    }
+
+    public function test_default_gateway_is_first_bank(): void
+    {
+        $this->assertInstanceOf(EstPos::class, $this->app->make(PosInterface::class));
+    }
+
+    public function test_event_dispatcher_interface_is_bound(): void
+    {
+        $this->assertInstanceOf(
+            EventDispatcherInterface::class,
+            $this->app->make(EventDispatcherInterface::class)
+        );
+    }
+
+    public function test_http_client_interface_is_bound(): void
+    {
+        $this->assertInstanceOf(
+            ClientInterface::class,
+            $this->app->make(ClientInterface::class)
+        );
+    }
+
+    public function test_gateway_resolved_by_bank_key(): void
+    {
+        $this->assertInstanceOf(PosInterface::class, $this->app->make('laravel-pos:gateway:est_bank'));
+        $this->assertInstanceOf(PosInterface::class, $this->app->make('laravel-pos:gateway:garanti_bank'));
+    }
+
+    public function test_each_bank_key_resolves_its_own_gateway_class(): void
+    {
+        $this->assertInstanceOf(EstPos::class, $this->app->make('laravel-pos:gateway:est_bank'));
+        $this->assertInstanceOf(GarantiPos::class, $this->app->make('laravel-pos:gateway:garanti_bank'));
+    }
+
+    public function test_all_banks_are_tagged(): void
+    {
+        $gateways = iterator_to_array($this->app->tagged('laravel-pos:gateway'));
+
+        $this->assertCount(2, $gateways);
+    }
+
+    public function test_config_is_publishable(): void
+    {
+        $paths = LaravelPosServiceProvider::pathsToPublish(LaravelPosServiceProvider::class, 'laravel-pos');
+
+        $this->assertNotEmpty($paths);
+        $sourceFiles = array_map('basename', array_keys($paths));
+        $this->assertContains('laravel-pos.php', $sourceFiles);
+    }
+
+    private function makeEstPosConfig(): array
+    {
+        return [
+            'gateway_class'     => EstPos::class,
+            'lang'              => PosInterface::LANG_TR,
+            'credentials'       => [
+                'payment_model' => PosInterface::MODEL_NON_SECURE,
+                'merchant_id'   => '700655000200',
+                'user_name'     => 'ISBANKAPI',
+                'user_password' => 'ISBANK07',
+                'enc_key'       => 'TRPS0200',
+            ],
+            'gateway_endpoints' => [
+                'payment_api'     => 'https://entegrasyon.asseco-see.com.tr/fim/api',
+                'gateway_3d'      => 'https://entegrasyon.asseco-see.com.tr/fim/est3Dgate',
+                'gateway_3d_host' => null,
+                'query_api'       => null,
+            ],
+            'gateway_configs'   => [],
+        ];
+    }
+
+    private function makeGarantiPosConfig(): array
+    {
+        return [
+            'gateway_class'     => GarantiPos::class,
+            'lang'              => PosInterface::LANG_TR,
+            'credentials'       => [
+                'payment_model'        => PosInterface::MODEL_NON_SECURE,
+                'merchant_id'          => '7000679',
+                'user_name'            => 'PROVAUT',
+                'user_password'        => '123qweASD',
+                'terminal_id'          => '30691298',
+                'enc_key'              => '12345678',
+                'refund_user_name'     => 'PROVRFN',
+                'refund_user_password' => '123qweASD',
+            ],
+            'gateway_endpoints' => [
+                'payment_api'     => 'https://sanalposprovtest.garanti.com.tr/VPServlet',
+                'gateway_3d'      => 'https://sanalposprovtest.garanti.com.tr/servlet/gt3dengine',
+                'gateway_3d_host' => null,
+                'query_api'       => null,
+            ],
+            'gateway_configs'   => [],
+        ];
+    }
+}

--- a/tests/LaravelPosServiceProviderTest.php
+++ b/tests/LaravelPosServiceProviderTest.php
@@ -83,7 +83,7 @@ class LaravelPosServiceProviderTest extends TestCase
 
     public function test_all_banks_are_tagged(): void
     {
-        $gateways = iterator_to_array($this->app->tagged('laravel-pos:gateway'));
+        $gateways = [...$this->app->tagged('laravel-pos:gateway')];
 
         $this->assertCount(2, $gateways);
     }
@@ -92,7 +92,7 @@ class LaravelPosServiceProviderTest extends TestCase
     {
         $registry = $this->app->make(\Mews\LaravelPos\GatewayRegistry::class);
         $viaKey   = $this->app->make('laravel-pos:gateway:est_bank');
-        $tagged   = iterator_to_array($this->app->tagged('laravel-pos:gateway'));
+        $tagged   = [...$this->app->tagged('laravel-pos:gateway')];
 
         $this->assertSame($viaKey, $registry->gateway('est_bank'));
         $this->assertSame($viaKey, $tagged[0]);

--- a/tests/LaravelPosServiceProviderTest.php
+++ b/tests/LaravelPosServiceProviderTest.php
@@ -61,6 +61,14 @@ class LaravelPosServiceProviderTest extends TestCase
         );
     }
 
+    public function test_account_factory_interface_is_bound(): void
+    {
+        $this->assertInstanceOf(
+            \Mews\LaravelPos\Factory\AccountFactory::class,
+            $this->app->make(\Mews\LaravelPos\Factory\AccountFactoryInterface::class)
+        );
+    }
+
     public function test_gateway_resolved_by_bank_key(): void
     {
         $this->assertInstanceOf(PosInterface::class, $this->app->make('laravel-pos:gateway:est_bank'));


### PR DESCRIPTION
### Yeni Özellikler

- **Laravel 13 desteği eklendi.**

- **`GatewayRegistry` servisi ve `LaravelPos` facade'i eklendi.**
  Gateway'lere artık container key'i yerine tip güvenli bir servis veya facade üzerinden erişilebilir:
  ```php
  // Servis injection
  public function __construct(private \Mews\LaravelPos\GatewayRegistry $registry) {}
  $pos = $this->registry->gateway('kuveytpos');

  // Facade
  $pos = \Mews\LaravelPos\Facades\LaravelPos::gateway('kuveytpos');

  // Tüm gateway'ler
  $all = $this->registry->all(); // PosInterface[]
  ```

- **`AccountFactoryInterface` ile özelleştirilebilir hesap fabrikası.**
  `mews/pos`'ta yeni çıkan bir gateway için `laravel-pos` güncellemesini beklemeden kendi
  implementasyonunuzu yazabilirsiniz. Bkz. [Özel AccountFactory Kullanımı](./docs/CUSTOM-ACCOUNT-FACTORY.md).


### İyileştirmeler

- **Gateway'ler artık ihtiyaç duyulduğunda oluşturuluyor (lazy loading).**
  Daha önce tüm bankalar için gateway nesneleri uygulama başlangıcında oluşturuluyordu.
  Artık her gateway yalnızca ilk erişimde oluşturulur ve sonraki çağrılarda önbellekten döner.

- **KuveytPos ve PayFor endpoint URL'leri güncellendi.**

---
